### PR TITLE
Modified the IISLog collection

### DIFF
--- a/articles/azure-monitor/platform/data-sources-iis-logs.md
+++ b/articles/azure-monitor/platform/data-sources-iis-logs.md
@@ -29,7 +29,7 @@ Configure IIS logs in Azure Monitor from the [Advanced Settings menu](agent-data
 
 
 ## Data collection
-Azure Monitor collects IIS log entries from each agent each time the log is closed and a new one is created. This frequency is controlled by the **Log File Rollover Schedule** setting for the IIS site which is once a day by default. For example, if the settings is **Hourly**, then Azure Monitor will collect the log each hour.  If the setting is **Daily**, then Azure Monitor will collect the log every 24 hours.
+Azure Monitor collects IIS log entries from each agent each time **the log timestamp change or a new one file is created**. Log is read every **5 minutes**. The frequency of new file creation is controlled by the **Log File Rollover Schedule** setting for the IIS site which is once a day by default. If, for any reason, IIS doesn't update timestamp before the rollover time, if the settings is **Hourly**, then Azure Monitor will collect the log each hour.  If the setting is **Daily**, then Azure Monitor will collect the log every 24 hours.
 
 
 ## IIS log record properties


### PR DESCRIPTION
IIS Log are collected at file timestamp change, every 5 minutes
Timestamp change when log is rotated base on rollover settings
IIS Log rollover settings are:
Timely (daily or hourly)
Based of file size

This match observed behavior during deliveries

antoniod@microsoft.com 